### PR TITLE
feat(PLAT-1248): Bumps mapbox-gl version to 0.38.0 to fix issue with Safari map labels not appearing

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "insert-css": "^2.0.0",
     "load-script": "^1.0.0",
     "lodash": "^4.5.1",
-    "mapbox-gl": "~0.35.0",
+    "mapbox-gl": "~0.38.0",
     "moment": "^2.12.0",
     "superagent": "^1.8.3",
     "uuid": "^2.0.1"

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-exports.mapboxStyles = 'https://api.tiles.mapbox.com/mapbox-gl-js/v0.35.0/mapbox-gl.css'
+exports.mapboxStyles = 'https://api.tiles.mapbox.com/mapbox-gl-js/v0.38.0/mapbox-gl.css'
 exports.mapboxGeocoder = 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v2.0.1/mapbox-gl-geocoder.js'
 exports.mapboxGeocoderStyles = 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v2.0.1/mapbox-gl-geocoder.css'
 exports.poweredByLogo = 'https://cdn.airmap.io/img/airmap-powered-logo.png'


### PR DESCRIPTION
Fixes: https://airmap.atlassian.net/browse/PLAT-1248, due to this issue: https://github.com/mapbox/mapbox-gl-js/issues/4607 fixed in version 0.38.0.